### PR TITLE
Fix duplicate DOCS entries when asciidoctor is present

### DIFF
--- a/pgxntool/base.mk
+++ b/pgxntool/base.mk
@@ -131,8 +131,10 @@ dist: html
 # But don't add it as an install or test dependency unless we do have asciidoc
 ifneq (,$(strip $(ASCIIDOC)))
 
-# Need to do this so install & co will pick up ALL targets. Unfortunately this can result in some duplication.
-DOCS += $(ASCIIDOC_HTML)
+# Need to do this so install & co will pick up ALL targets. Use filter-out to
+# avoid duplicating html files that are already in DOCS (e.g. committed .html
+# alongside their .adoc source).
+DOCS := $(sort $(filter-out $(ASCIIDOC_HTML),$(DOCS)) $(ASCIIDOC_HTML))
 
 # Also need to add html as a dep to all (which will get picked up by install & installcheck
 all: html


### PR DESCRIPTION
## Problem

When `asciidoctor` is installed, `make install` fails with:

```
/usr/bin/install: will not overwrite just-created '.../object_reference.html' with './/doc/object_reference.html'
```

`DOCS` ends up containing `doc/object_reference.html` twice:

1. Line 23 of `pgxntool/base.mk`: `$(wildcard doc/*)` picks up the committed `.html` file
2. Line 135: `DOCS += $(ASCIIDOC_HTML)` adds the same path again as a generated asciidoc target

Both paths expand to the same filename, so `install` receives it twice in one invocation and refuses to overwrite a file it just wrote.

## Fix

Use `$(filter-out)` to remove any `ASCIIDOC_HTML` files already present in `DOCS` before appending, then `$(sort)` to deduplicate. This is the same approach already taken in Postgres-Extensions/pgxntool 2.x.

## Reproducer

Any project that commits its generated `.html` doc alongside its `.adoc` source, with `asciidoctor` in PATH.